### PR TITLE
Create proper Dockerfile so Puppet installs on containers

### DIFF
--- a/manifests/centosimage.pp
+++ b/manifests/centosimage.pp
@@ -1,10 +1,6 @@
 class puppetfactory::centosimage (
-  $master_address = $puppetmaster,
+  $puppetmaster,
 ) {
-
-  file { '/var/docker':
-    ensure => directory,
-  }
 
   # CentOS agent image
   file { '/var/docker/centosagent/':
@@ -17,12 +13,13 @@ class puppetfactory::centosimage (
   file { '/var/docker/centosagent/Dockerfile':
     ensure  => present,
     content => epp('puppetfactory/centos.dockerfile.epp',{
-        'puppetmaster' => $master_address,
+        'puppetmaster' => $puppetmaster,
       }),
     notify  => Docker::Image['centosagent'],
   }
 
   docker::image { 'centosagent':
     docker_dir => '/var/docker/centosagent/',
+    require    => File['/var/docker/centosagent/Dockerfile'],
   }
 }

--- a/manifests/dockerenv.pp
+++ b/manifests/dockerenv.pp
@@ -9,8 +9,6 @@ class puppetfactory::dockerenv {
     before => Class['docker'],
   }
 
-  $puppetmaster = pick($puppetfactory::master, $servername)
-
   sysctl {'net.ipv4.ip_forward':
     ensure    => present,
     value     => '1',
@@ -27,7 +25,12 @@ class puppetfactory::dockerenv {
     ensure => present,
   }
 
-  include puppetfactory::centosimage
-  include puppetfactory::ubuntuimage
-}
+  file { '/var/docker':
+    ensure => directory,
+  }
 
+  class { [ 'puppetfactory::centosimage', 'puppetfactory::ubuntuimage']:
+    puppetmaster => pick($puppetfactory::master, $servername),
+  }
+
+}

--- a/manifests/ubuntuimage.pp
+++ b/manifests/ubuntuimage.pp
@@ -1,4 +1,6 @@
-class puppetfactory::ubuntuimage {
+class puppetfactory::ubuntuimage (
+  $puppetmaster,
+) {
 
   # Ubuntu agent image
   file { '/var/docker/ubuntuagent/':
@@ -11,16 +13,13 @@ class puppetfactory::ubuntuimage {
   file { '/var/docker/ubuntuagent/Dockerfile':
     ensure  => present,
     content => epp('puppetfactory/ubuntu.dockerfile.epp',{
-        'puppetmaster' => $puppetmaster
+        'puppetmaster' => $puppetmaster,
       }),
-    require => File['/var/docker/ubuntuagent/'],
-    notify => Docker::Image['ubuntuagent'],
+    notify  => Docker::Image['ubuntuagent'],
   }
 
   docker::image { 'ubuntuagent':
     docker_dir => '/var/docker/ubuntuagent/',
-    require     => File['/var/docker/ubuntuagent/Dockerfile'],
+    require    => File['/var/docker/ubuntuagent/Dockerfile'],
   }
-  
 }
-


### PR DESCRIPTION
This ensures that the master's address makes it to the containers so
that Puppet actually installs properly. It also cleans up some
idempotence problems

TRAINTECH-1166 #resolved #time 2h
TRAINTECH-1167 #resolved #time 2h