### PR TITLE
Hotfix: Hardcode master url in Dockerfile

### DIFF
--- a/templates/centos.dockerfile.epp
+++ b/templates/centos.dockerfile.epp
@@ -10,7 +10,7 @@ ADD base_local.repo /etc/yum.repos.d/base_local.repo
 ADD epel_local.repo /etc/yum.repos.d/epel_local.repo
 ADD updates_local.repo /etc/yum.repos.d/updates_local.repo
 ADD vimrc /root/.vimrc
-RUN echo 'if ! hash puppet; then curl -k https://<%= $puppetmaster %>:8140/packages/current/install.bash | sudo bash; fi' >> /root/.bashrc
+RUN echo 'if ! hash puppet; then curl -k https://master.puppetlabs.vm:8140/packages/current/install.bash | sudo bash; fi' >> /root/.bashrc
 RUN mkdir -p /etc/puppetlabs/code/modules
 EXPOSE 3306 80
 CMD ["/sbin/init"]


### PR DESCRIPTION
The variable wasn't getting interpolated properly which was leading to a value of "https://:8140". There is another fix in master which removes this file altogether in favor of the dockeragent module, but it is not ready for release. This is a temporary patch until those major changes are ready.