### PR TITLE
bump max auth retries

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -139,6 +139,7 @@ class puppetfactory (
     permit_root_login              => $allow_root,
     password_authentication_groups => ['puppetfactory'],
     use_pam                        => 'yes',
+    max_auth_retries               => 30,
     host_keys                      => ['/etc/ssh/ssh_host_rsa_key','/etc/ssh/ssh_host_ecdsa_key', '/etc/ssh/ssh_host_ed25519_key'],
   }
 


### PR DESCRIPTION
This allows those with several ssh keys to log in. It defaults to only 2