### PR TITLE
Send headers to avoid redirecting to 127.0.0.1

### DIFF
--- a/files/default.conf
+++ b/files/default.conf
@@ -24,12 +24,16 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $http_host;
     proxy_set_header X-NginX-Proxy true;
-
   }
 
   # Match users UID and forward to their port
   location ~ /port/(?<user_port>.*) {
     proxy_pass http://127.0.0.1:$user_port;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Original-Request $request_uri;
+    proxy_set_header Host $http_host;
+    proxy_set_header X-NginX-Proxy true;
   }
 
   error_page  404               /404.html;


### PR DESCRIPTION
This solves part of the problem in this ticket. The other issue is resolved by a patch upstream to the wordpress module and upcoming courseware instructions.

COURSES-3327 #resolved #time 2h